### PR TITLE
chore: Use google/cloud-sdk:alpine image instead of slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-
-FROM google/cloud-sdk:slim
+FROM google/cloud-sdk:alpine
 LABEL maintainer="engineering@compensate.com"
 
-RUN  apt-get -y install unzip && \
+RUN apk --no-cache add curl unzip && \
     curl -o terraform.zip https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_linux_amd64.zip && \
     unzip terraform.zip && \
     chmod +x terraform && \
     mv terraform /usr/local/bin && \
-    apt-get -y remove unzip && \
-    apt-get clean && \
     rm terraform.zip


### PR DESCRIPTION
Size of the image from 1.2GB to 658MB