### PR TITLE
chore: Upgrade Terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:alpine
 LABEL maintainer="engineering@compensate.com"
 
 RUN apk --no-cache add curl unzip && \
-    curl -o terraform.zip https://releases.hashicorp.com/terraform/1.0.3/terraform_1.0.3_linux_amd64.zip && \
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_linux_amd64.zip && \
     unzip terraform.zip && \
     chmod +x terraform && \
     mv terraform /usr/local/bin && \


### PR DESCRIPTION
This enables CI/CD in those contexts where a minimum version is set to the patch level. For our contexts (`dev`, `common` and `production`) we only specify a minimum patch version in the `production` and `common` context. This is to tie the tool we use to keep track of our infra (Terraform) to a very specific version in key infrastructure, whilst leaving development contexts more free range.