### PR TITLE
chore: Upgrade Terraform builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:alpine
 LABEL maintainer="engineering@compensate.com"
 
 RUN apk --no-cache add curl unzip && \
-    curl -o terraform.zip https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_linux_amd64.zip && \
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_linux_amd64.zip && \
     unzip terraform.zip && \
     chmod +x terraform && \
     mv terraform /usr/local/bin && \


### PR DESCRIPTION
https://trello.com/c/g4AiE6KD/973-upgrade-kubernetes-manifests-to-use-v1-stable-apis

Upon merge, follow [README.md](https://github.com/Compensate-Operations/cloudbuild-terraform/blob/main/README.md) (build and push image to registry). Follow this with upgrades for `dev` and `production` Terraform tooling to not block the CI/CD pipeline.